### PR TITLE
Feat: Add journal entry creation via POST /api/entries and frontend form

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6,36 +6,60 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(cors());
+app.use(express.json()); // Required for parsing JSON bodies
 
 app.use((req, res, next) => {
   console.log(`[${req.method}] ${req.url}`);
   next();
 });
 
-// Main API route
-app.get('/api/entries', (_, res) => {
-  const sampleEntries = [
-    {
-      id: '1',
-      title: 'Morning Hike',
-      content: 'Went on a hike today in the hills.',
-      timestamp: '2025-08-20T08:00:00Z',
-    },
-    {
-      id: '2',
-      title: 'Evening Reflection',
-      content: 'Felt grateful today. Journaling before bed.',
-      timestamp: '2025-08-20T20:45:00Z',
-    },
-  ];
-  res.json(sampleEntries);
-});
+// In-memory sample entries
+const entries = [
+  {
+    id: '1',
+    title: 'Morning Hike',
+    content: 'Went on a hike today in the hills.',
+    timestamp: '2025-08-20T08:00:00Z',
+  },
+  {
+    id: '2',
+    title: 'Evening Reflection',
+    content: 'Felt grateful today. Journaling before bed.',
+    timestamp: '2025-08-20T20:45:00Z',
+  },
+];
 
-// Optional root route for Render or sanity check
-app.get('/', (_, res) => {
+
+// Main API route
+app.get(['/', '/api', '/api/'], (_, res) => {
   res.send('Hello from Timekin API Server side!');
 });
 
+// Get all journal entries
+app.get('/api/entries', (_, res) => {
+  res.json(entries);
+});
+
+// Create a new journal entry
+app.post('/api/entries', (req, res) => {
+  const { title, content, timestamp } = req.body;
+
+  if (!title || !content || !timestamp) {
+    return res.status(400).json({ error: 'Missing fields in request' });
+  }
+
+  const newEntry = {
+    id: (entries.length + 1).toString(),
+    title,
+    content,
+    timestamp,
+  };
+
+  entries.push(newEntry);
+  res.status(201).json(newEntry);
+});
+
+// Start server
 app.listen(PORT, () => {
   console.log(`✅ Server running at http://localhost:${PORT}`);
 });

--- a/frontend/src/pages/NewEntry.tsx
+++ b/frontend/src/pages/NewEntry.tsx
@@ -1,8 +1,75 @@
-export default function NewEntry() {
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const NewEntry = () => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const newEntry = {
+      title,
+      content,
+      timestamp: new Date().toISOString(),
+    };
+
+    try {
+      const res = await fetch(`${__API_BASE__}/api/entries`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(newEntry),
+      });
+
+      if (res.ok) {
+        navigate('/');
+      } else {
+        alert('Failed to create entry.');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Error creating entry.');
+    }
+  };
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-2">New Journal Entry</h1>
-      <p>Form placeholder</p>
+    <div className="max-w-2xl mx-auto p-6">
+      <h2 className="text-2xl font-bold mb-4">New Journal Entry</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Title</label>
+          <input
+            type="text"
+            className="w-full border rounded p-2"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Content</label>
+          <textarea
+            className="w-full border rounded p-2"
+            rows={6}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            required
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          Save Entry
+        </button>
+      </form>
     </div>
   );
-}
+};
+
+export default NewEntry;


### PR DESCRIPTION
## Summary

This PR introduces end-to-end functionality for creating new journal entries.

### Backend
- Added `POST /api/entries` route to accept new journal entry data (title, content, timestamp).
- Stores entries in-memory for now (will move to MongoDB in future).

### Frontend
- Created `NewEntry.tsx` component with a form to submit new journal entries.
- Integrated `fetch` POST request to backend upon submission.
- Navigation returns user to homepage (`/`) upon successful submission.

### Shared
- API communication uses `__API_BASE__` for environment-agnostic routing.
- Full create-and-read loop now demoable in both local and deployed environments.

## Next Steps
- Add persistent storage with MongoDB.
- Implement `/entry/:id` detail view.
- Begin work on image, location, and mood support.
