### PR TITLE
Add Entry View Page for Viewing Individual Journal Entries

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -40,6 +40,18 @@ app.get('/api/entries', (_, res) => {
   res.json(entries);
 });
 
+
+// Get a specific journal entry by ID
+app.get('/api/entries/:id', (req, res) => {
+  const { id } = req.params;
+  const entry = entries.find((e) => e.id === id);
+  if (entry) {
+    res.json(entry);
+  } else {
+    res.status(404).json({ error: 'Entry not found' });
+  }
+});
+
 // Create a new journal entry
 app.post('/api/entries', (req, res) => {
   const { title, content, timestamp } = req.body;

--- a/frontend/src/pages/EntryView.tsx
+++ b/frontend/src/pages/EntryView.tsx
@@ -1,12 +1,44 @@
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-export default function EntryView() {
-  const { id } = useParams();
+type JournalEntry = {
+  id: string;
+  title: string;
+  content: string;
+  timestamp: string;
+};
+
+const EntryView = () => {
+  const { id } = useParams<{ id: string }>();
+  const [entry, setEntry] = useState<JournalEntry | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`${__API_BASE__}/api/entries/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error('Entry not found');
+        return res.json();
+      })
+      .then((data) => {
+        setEntry(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch entry:', err);
+        setLoading(false);
+      });
+  }, [id]);
+
+  if (loading) return <p className="p-6">Loading...</p>;
+  if (!entry) return <p className="p-6 text-red-500">Entry not found.</p>;
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-2">Entry: {id}</h1>
-      <p>Entry detail placeholder</p>
+    <div className="max-w-2xl mx-auto p-6">
+      <h2 className="text-2xl font-bold mb-2">{entry.title}</h2>
+      <p className="text-sm text-gray-500 mb-4">{new Date(entry.timestamp).toLocaleString()}</p>
+      <p>{entry.content}</p>
     </div>
   );
-}
+};
+
+export default EntryView;


### PR DESCRIPTION
### Summary

This PR adds functionality to view individual journal entries by ID.

### Changes Included

- Implemented `EntryView.tsx` page in frontend
- Hooked up dynamic route `/entry/:id`
- Displays title, timestamp, and content of a single entry
- Error message shown if entry is not found

### Backend

- Added `GET /api/entries/:id` route to return a single entry based on ID

### Demo

- Navigate to `/entry/1` or `/entry/2` locally to view seeded sample entries
